### PR TITLE
Option Order/Position in Usage Message

### DIFF
--- a/lib/MooseX/App/Meta/Role/Class/Base.pm
+++ b/lib/MooseX/App/Meta/Role/Class/Base.pm
@@ -656,14 +656,17 @@ sub command_usage_options {
     $metaclass ||= $self;
     
     my @options;
-    foreach my $attribute ($self->command_usage_attributes($metaclass,[qw(option proto)])) {
+    foreach my $attribute (
+        sort {
+            $a->cmd_position <=> $b->cmd_position ||
+            $a->cmd_usage_name cmp $b->cmd_usage_name
+        } $self->command_usage_attributes($metaclass,[qw(option proto)])
+    ) {
         push(@options,[
             $attribute->cmd_usage_name(),
             $attribute->cmd_usage_description()
         ]);
     }
-    
-    @options = sort { $a->[0] cmp $b->[0] } @options;
     
     return
         unless scalar @options > 0;


### PR DESCRIPTION
According to the documentation for MooseX::App, the ordering of options / parameters in the usage message is something that can be altered by specifying the 'cmd_position' attribute property, however it does not appear to be functional for options.  

I am not sure if this was intended and the documentation is incorrect, but this patch enables the feature for options.